### PR TITLE
Adds support for request headers

### DIFF
--- a/packages/graphiql/resources/renderExample.js
+++ b/packages/graphiql/resources/renderExample.js
@@ -72,7 +72,7 @@ function updateURL() {
 // Defines a GraphQL fetcher using the fetch API. You're not required to
 // use fetch, and could instead implement graphQLFetcher however you like,
 // as long as it returns a Promise or Observable.
-function graphQLFetcher(graphQLParams) {
+function graphQLFetcher(graphQLParams, headers = {}) {
   // When working locally, the example expects a GraphQL server at the path /graphql.
   // In a PR preview, it connects to the Star Wars API externally.
   // Change this to point wherever you host your GraphQL server.
@@ -85,6 +85,7 @@ function graphQLFetcher(graphQLParams) {
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',
+      ...headers,
     },
     body: JSON.stringify(graphQLParams),
     credentials: 'omit',

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -80,6 +80,7 @@ type FetcherResult =
     };
 export type Fetcher = (
   graphQLParams: FetcherParams,
+  headers?: string,
 ) => Promise<FetcherResult> | Observable<FetcherResult>;
 
 type OnMouseMoveFn = Maybe<
@@ -92,14 +93,17 @@ type GraphiQLProps = {
   schema?: GraphQLSchema;
   query?: string;
   variables?: string;
+  headers?: string;
   operationName?: string;
   response?: string;
   storage?: Storage;
   defaultQuery?: string;
   defaultVariableEditorOpen?: boolean;
+  defaultHeaderEditorOpen?: boolean;
   onCopyQuery?: (query?: string) => void;
   onEditQuery?: () => void;
   onEditVariables?: (value: string) => void;
+  onEditHeaders?: (value: string) => void;
   onEditOperationName?: (operationName: string) => void;
   onToggleDocs?: (docExplorerOpen: boolean) => void;
   getDefaultFieldNames?: GetDefaultFieldNamesFn;
@@ -114,12 +118,15 @@ type GraphiQLState = {
   schema?: GraphQLSchema;
   query?: string;
   variables?: string;
+  headers?: string;
   operationName?: string;
   docExplorerOpen: boolean;
   response?: string;
   editorFlex: number;
   variableEditorOpen: boolean;
+  headerEditorOpen: boolean;
   variableEditorHeight: number;
+  headerEditorHeight: number;
   historyPaneOpen: boolean;
   docExplorerWidth: number;
   isWaitingForResponse: boolean;
@@ -160,6 +167,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
   graphiqlContainer: Maybe<HTMLDivElement>;
   resultComponent: Maybe<ResultViewer>;
   variableEditorComponent: Maybe<VariableEditor>;
+  headerEditorComponent: Maybe<VariableEditor>;
   _queryHistory: Maybe<QueryHistory>;
   editorBarComponent: Maybe<HTMLDivElement>;
   queryEditorComponent: Maybe<QueryEditor>;
@@ -195,6 +203,12 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
         ? props.variables
         : this._storage.get('variables');
 
+    // Determine the initial headers to display.
+    const headers =
+      props.headers !== undefined
+        ? props.headers
+        : this._storage.get('headers');
+
     // Determine the initial operationName to use.
     const operationName =
       props.operationName !== undefined
@@ -219,18 +233,27 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
         ? props.defaultVariableEditorOpen
         : Boolean(variables);
 
+    const headerEditorOpen =
+      props.defaultHeaderEditorOpen !== undefined
+        ? props.defaultHeaderEditorOpen
+        : Boolean(headers);
+
     // Initialize state
     this.state = {
       schema: props.schema,
       query,
       variables: variables as string,
+      headers: headers as string,
       operationName,
       docExplorerOpen,
       response: props.response,
       editorFlex: Number(this._storage.get('editorFlex')) || 1,
       variableEditorOpen,
+      headerEditorOpen,
       variableEditorHeight:
         Number(this._storage.get('variableEditorHeight')) || 200,
+      headerEditorHeight:
+        Number(this._storage.get('headerEditorHeight')) || 200,
       historyPaneOpen: this._storage.get('historyPaneOpen') === 'true' || false,
       docExplorerWidth:
         Number(this._storage.get('docExplorerWidth')) ||
@@ -266,6 +289,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
     let nextSchema = this.state.schema;
     let nextQuery = this.state.query;
     let nextVariables = this.state.variables;
+    let nextHeaders = this.state.headers;
     let nextOperationName = this.state.operationName;
     let nextResponse = this.state.response;
 
@@ -277,6 +301,9 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
     }
     if (nextProps.variables !== undefined) {
       nextVariables = nextProps.variables;
+    }
+    if (nextProps.headers !== undefined) {
+      nextHeaders = nextProps.headers;
     }
     if (nextProps.operationName !== undefined) {
       nextOperationName = nextProps.operationName;
@@ -319,6 +346,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
         schema: nextSchema,
         query: nextQuery,
         variables: nextVariables,
+        headers: nextHeaders,
         operationName: nextOperationName,
         response: nextResponse,
       },
@@ -352,6 +380,9 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
     }
     if (this.state.variables) {
       this._storage.set('variables', this.state.variables);
+    }
+    if (this.state.headers) {
+      this._storage.set('headers', this.state.headers);
     }
     if (this.state.operationName) {
       this._storage.set('operationName', this.state.operationName);
@@ -437,6 +468,11 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
       height: variableOpen ? this.state.variableEditorHeight : undefined,
     };
 
+    const headerOpen = this.state.headerEditorOpen;
+    const headerStyle = {
+      height: headerOpen ? this.state.headerEditorHeight : undefined,
+    };
+
     return (
       <div
         ref={n => {
@@ -451,6 +487,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
             operationName={this.state.operationName}
             query={this.state.query}
             variables={this.state.variables}
+            headers={this.state.headers}
             onSelectQuery={this.handleSelectHistoryQuery}
             storage={this._storage}
             queryID={this._editorQueryID}>
@@ -533,6 +570,34 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
                   onRunQuery={this.handleEditorRunQuery}
                   editorTheme={this.props.editorTheme}
                   readOnly={this.props.readOnly}
+                  mode='graphql-variables'
+                />
+              </section>
+              <section
+                className="header-editor"
+                style={headerStyle}
+                aria-label="Request Headers">
+                <div
+                  className="header-editor-title"
+                  id="header-editor-title"
+                  style={{
+                    cursor: headerOpen ? 'row-resize' : 'n-resize',
+                  }}
+                  onMouseDown={this.handleHeaderResizeStart}>
+                  {'Request Headers'}
+                </div>
+                <VariableEditor
+                  ref={n => {
+                    this.headerEditorComponent = n;
+                  }}
+                  value={this.state.headers}
+                  onEdit={this.handleEditHeaders}
+                  onPrettifyQuery={this.handlePrettifyQuery}
+                  onMergeQuery={this.handleMergeQuery}
+                  onRunQuery={this.handleEditorRunQuery}
+                  editorTheme={this.props.editorTheme}
+                  readOnly={this.props.readOnly}
+                  mode={{ name: 'javascript', json: true }}
                 />
               </section>
             </div>
@@ -765,11 +830,13 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
   private _fetchQuery(
     query: string,
     variables: string,
+    headers: string,
     operationName: string,
     cb: (value: FetcherResult) => any,
   ) {
     const fetcher = this.props.fetcher;
     let jsonVariables = null;
+    let jsonHeaders = null;
 
     try {
       jsonVariables =
@@ -782,11 +849,24 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
       throw new Error('Variables are not a JSON object.');
     }
 
-    const fetch = fetcher({
-      query,
-      variables: jsonVariables,
-      operationName,
-    });
+    try {
+      jsonHeaders = headers && headers.trim() !== '' ? JSON.parse(headers) : {};
+    } catch (error) {
+      throw new Error(`Headers are invalid JSON: ${error.message}.`);
+    }
+
+    if (typeof jsonHeaders !== 'object') {
+      throw new Error('Headers are not a JSON object.');
+    }
+
+    const fetch = fetcher(
+      {
+        query,
+        variables: jsonVariables,
+        operationName,
+      },
+      jsonHeaders,
+    );
 
     if (isPromise(fetch)) {
       // If fetcher returned a Promise, then call the callback when the promise
@@ -841,6 +921,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
     // the current query from the editor.
     const editedQuery = this.autoCompleteLeafs() || this.state.query;
     const variables = this.state.variables;
+    const headers = this.state.headers;
     let operationName = this.state.operationName;
 
     // If an operation was explicitly provided, different from the current
@@ -858,13 +939,19 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
       });
 
       if (this._queryHistory) {
-        this._queryHistory.updateHistory(editedQuery, variables, operationName);
+        this._queryHistory.updateHistory(
+          editedQuery,
+          variables,
+          headers,
+          operationName,
+        );
       }
 
       // _fetchQuery may return a subscription.
       const subscription = this._fetchQuery(
         editedQuery as string,
         variables as string,
+        headers as string,
         operationName as string,
         (result: FetcherResult) => {
           if (queryID === this._editorQueryID) {
@@ -1036,6 +1123,13 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
     }
   };
 
+  handleEditHeaders = (value: string) => {
+    this.setState({ headers: value });
+    if (this.props.onEditHeaders) {
+      this.props.onEditHeaders(value);
+    }
+  };
+
   handleEditOperationName = (operationName: string) => {
     const onEditOperationName = this.props.onEditOperationName;
     if (onEditOperationName) {
@@ -1100,6 +1194,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
   handleSelectHistoryQuery = (
     query?: string,
     variables?: string,
+    headers?: string,
     operationName?: string,
   ) => {
     if (query) {
@@ -1107,6 +1202,9 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
     }
     if (variables) {
       this.handleEditVariables(variables);
+    }
+    if (headers) {
+      this.handleEditHeaders(headers);
     }
     if (operationName) {
       this.handleEditOperationName(operationName);
@@ -1217,16 +1315,17 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
     });
   };
 
-  private handleVariableResizeStart: MouseEventHandler<
-    HTMLDivElement
-  > = downEvent => {
+  private handleEditorResizeStart = (
+    downEvent: React.MouseEvent<HTMLDivElement, MouseEvent>,
+    openVariableName: 'variableEditorOpen' | 'headerEditorOpen',
+    heightVariableName: 'variableEditorHeight' | 'headerEditorHeight',
+  ) => {
     downEvent.preventDefault();
 
     let didMove = false;
-    const wasOpen = this.state.variableEditorOpen;
-    const hadHeight = this.state.variableEditorHeight;
-    const offset = downEvent.clientY - getTop(downEvent.target as HTMLElement);
-
+    const wasOpen = this.state[openVariableName];
+    const hadHeight = this.state[heightVariableName];
+    const offset = downEvent.clientY;
     let onMouseMove: OnMouseMoveFn = moveEvent => {
       if (moveEvent.buttons === 0) {
         return onMouseUp!();
@@ -1234,25 +1333,24 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
 
       didMove = true;
 
-      const editorBar = this.editorBarComponent as HTMLElement;
-      const topSize = moveEvent.clientY - getTop(editorBar) - offset;
-      const bottomSize = editorBar.clientHeight - topSize;
-      if (bottomSize < 60) {
-        this.setState({
-          variableEditorOpen: false,
-          variableEditorHeight: hadHeight,
-        });
+      const newHeight = hadHeight + offset - moveEvent.clientY;
+      const newState = {} as Pick<GraphiQLState, keyof GraphiQLState>;
+
+      if (newHeight < 60) {
+        newState[openVariableName] = false;
+        newState[heightVariableName] = hadHeight;
       } else {
-        this.setState({
-          variableEditorOpen: true,
-          variableEditorHeight: bottomSize,
-        });
+        newState[openVariableName] = true;
+        newState[heightVariableName] = newHeight;
       }
+      this.setState(newState);
     };
 
     let onMouseUp: OnMouseUpFn = () => {
       if (!didMove) {
-        this.setState({ variableEditorOpen: !wasOpen });
+        this.setState({
+          [openVariableName]: !wasOpen } as unknown as Pick<GraphiQLState, keyof GraphiQLState>
+        );
       }
 
       document.removeEventListener('mousemove', onMouseMove!);
@@ -1263,6 +1361,26 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
 
     document.addEventListener('mousemove', onMouseMove);
     document.addEventListener('mouseup', onMouseUp);
+  };
+  
+  private handleVariableResizeStart: MouseEventHandler<
+    HTMLDivElement
+  > = downEvent => {
+    this.handleEditorResizeStart(
+      downEvent,
+      'variableEditorOpen',
+      'variableEditorHeight',
+    )
+  };
+
+  private handleHeaderResizeStart: MouseEventHandler<
+    HTMLDivElement
+  > = downEvent => {
+    this.handleEditorResizeStart(
+      downEvent,
+      'headerEditorOpen',
+      'headerEditorHeight',
+    )
   };
 }
 

--- a/packages/graphiql/src/components/HistoryQuery.tsx
+++ b/packages/graphiql/src/components/HistoryQuery.tsx
@@ -11,6 +11,7 @@ import { QueryStoreItem } from 'src/utility/QueryStore';
 export type HandleEditLabelFn = (
   query?: string,
   variables?: string,
+  headers?: string,
   operationName?: string,
   label?: string,
   favorite?: boolean,
@@ -19,6 +20,7 @@ export type HandleEditLabelFn = (
 export type HandleToggleFavoriteFn = (
   query?: string,
   variables?: string,
+  headers?: string,
   operationName?: string,
   label?: string,
   favorite?: boolean,
@@ -27,6 +29,7 @@ export type HandleToggleFavoriteFn = (
 export type HandleSelectQueryFn = (
   query?: string,
   variables?: string,
+  headers?: string,
   operationName?: string,
   label?: string,
 ) => void;
@@ -101,6 +104,7 @@ export default class HistoryQuery extends React.Component<
     this.props.onSelect(
       this.props.query,
       this.props.variables,
+      this.props.headers,
       this.props.operationName,
       this.props.label,
     );
@@ -111,6 +115,7 @@ export default class HistoryQuery extends React.Component<
     this.props.handleToggleFavorite(
       this.props.query,
       this.props.variables,
+      this.props.headers,
       this.props.operationName,
       this.props.label,
       this.props.favorite,
@@ -123,6 +128,7 @@ export default class HistoryQuery extends React.Component<
     this.props.handleEditLabel(
       this.props.query,
       this.props.variables,
+      this.props.headers,
       this.props.operationName,
       e.target.value,
       this.props.favorite,
@@ -136,6 +142,7 @@ export default class HistoryQuery extends React.Component<
       this.props.handleEditLabel(
         this.props.query,
         this.props.variables,
+        this.props.headers,
         this.props.operationName,
         e.currentTarget.value,
         this.props.favorite,

--- a/packages/graphiql/src/components/QueryHistory.tsx
+++ b/packages/graphiql/src/components/QueryHistory.tsx
@@ -21,6 +21,7 @@ const MAX_HISTORY_LENGTH = 20;
 const shouldSaveQuery = (
   query?: string,
   variables?: string,
+  headers?: string,
   lastQuerySaved?: QueryStoreItem,
 ) => {
   if (!query) {
@@ -42,11 +43,15 @@ const shouldSaveQuery = (
   }
   if (JSON.stringify(query) === JSON.stringify(lastQuerySaved.query)) {
     if (
-      JSON.stringify(variables) === JSON.stringify(lastQuerySaved.variables)
+      JSON.stringify(variables) === JSON.stringify(lastQuerySaved.variables) &&
+      JSON.stringify(headers) === JSON.stringify(lastQuerySaved.headers)
     ) {
       return false;
     }
     if (variables && !lastQuerySaved.variables) {
+      return false;
+    }
+    if (headers && !lastQuerySaved.headers) {
       return false;
     }
   }
@@ -56,6 +61,7 @@ const shouldSaveQuery = (
 type QueryHistoryProps = {
   query?: string;
   variables?: string;
+  headers?: string;
   operationName?: string;
   queryID?: number;
   onSelectQuery: HandleSelectQueryFn;
@@ -116,12 +122,21 @@ export class QueryHistory extends React.Component<
   updateHistory = (
     query?: string,
     variables?: string,
+    headers?: string,
     operationName?: string,
   ) => {
-    if (shouldSaveQuery(query, variables, this.historyStore.fetchRecent())) {
+    if (
+      shouldSaveQuery(
+        query,
+        variables,
+        headers,
+        this.historyStore.fetchRecent(),
+      )
+    ) {
       this.historyStore.push({
         query,
         variables,
+        headers,
         operationName,
       });
       const historyQueries = this.historyStore.items;
@@ -137,6 +152,7 @@ export class QueryHistory extends React.Component<
   toggleFavorite: HandleToggleFavoriteFn = (
     query,
     variables,
+    headers,
     operationName,
     label,
     favorite,
@@ -144,6 +160,7 @@ export class QueryHistory extends React.Component<
     const item: QueryStoreItem = {
       query,
       variables,
+      headers,
       operationName,
       label,
     };
@@ -163,6 +180,7 @@ export class QueryHistory extends React.Component<
   editLabel: HandleEditLabelFn = (
     query,
     variables,
+    headers,
     operationName,
     label,
     favorite,
@@ -170,6 +188,7 @@ export class QueryHistory extends React.Component<
     const item = {
       query,
       variables,
+      headers,
       operationName,
       label,
     };

--- a/packages/graphiql/src/components/VariableEditor.tsx
+++ b/packages/graphiql/src/components/VariableEditor.tsx
@@ -26,11 +26,12 @@ type VariableEditorProps = {
   value?: string;
   onEdit: (value: string) => void;
   readOnly?: boolean;
-  onHintInformationRender: (value: HTMLDivElement) => void;
+  onHintInformationRender?: (value: HTMLDivElement) => void;
   onPrettifyQuery: (value?: string) => void;
   onMergeQuery: (value?: string) => void;
   onRunQuery: (value?: string) => void;
   editorTheme?: string;
+  mode: string | object,
 };
 
 /**
@@ -84,7 +85,7 @@ export class VariableEditor extends React.Component<VariableEditorProps> {
       value: this.props.value || '',
       lineNumbers: true,
       tabSize: 2,
-      mode: 'graphql-variables',
+      mode: this.props.mode,
       theme: this.props.editorTheme || 'graphiql',
       keyMap: 'sublime',
       autoCloseBrackets: true,
@@ -249,6 +250,8 @@ export class VariableEditor extends React.Component<VariableEditorProps> {
     instance: CM.Editor,
     changeObj?: CM.EditorChangeLinkedList,
   ) => {
-    onHasCompletion(instance, changeObj, this.props.onHintInformationRender);
+    if (this.props.onHintInformationRender) {
+      onHasCompletion(instance, changeObj, this.props.onHintInformationRender);
+    }
   };
 }

--- a/packages/graphiql/src/css/app.css
+++ b/packages/graphiql/src/css/app.css
@@ -161,14 +161,15 @@
   position: relative;
 }
 
-.graphiql-container .variable-editor {
+.graphiql-container .variable-editor, .graphiql-container .header-editor {
   display: flex;
   flex-direction: column;
   height: 30px;
   position: relative;
 }
 
-.graphiql-container .variable-editor-title {
+.graphiql-container .variable-editor-title,
+.graphiql-container .header-editor-title {
   background: #eeeeee;
   border-bottom: 1px solid #d6d6d6;
   border-top: 1px solid #e0e0e0;

--- a/packages/graphiql/src/utility/QueryStore.ts
+++ b/packages/graphiql/src/utility/QueryStore.ts
@@ -9,6 +9,7 @@ import StorageAPI from './StorageAPI';
 export type QueryStoreItem = {
   query?: string;
   variables?: string;
+  headers?: string;
   operationName?: string;
   label?: string;
   favorite?: boolean;
@@ -34,6 +35,7 @@ export default class QueryStore {
       x =>
         x.query === item.query &&
         x.variables === item.variables &&
+        x.headers === item.headers &&
         x.operationName === item.operationName,
     );
   }
@@ -43,6 +45,7 @@ export default class QueryStore {
       x =>
         x.query === item.query &&
         x.variables === item.variables &&
+        x.headers === item.headers &&
         x.operationName === item.operationName,
     );
     if (itemIndex !== -1) {
@@ -56,6 +59,7 @@ export default class QueryStore {
       x =>
         x.query === item.query &&
         x.variables === item.variables &&
+        x.headers === item.headers &&
         x.operationName === item.operationName,
     );
     if (itemIndex !== -1) {


### PR DESCRIPTION
This PR adds support for request headers to graphiql.

The functionality (and usage) is almost identical to that of variables (since they're basically a second type of variable). The main change is that these are now propagated to the fetch request, where they're merged against the default headers.

This also features a small change to the way the variable/header panels are resized, since the introduction of a second panel cause that to break (the variables panel would jump around when resizing it).

Otherwise, this only features a little bit of refactoring to remove some redundancy.