### PR TITLE
Adding header linters

### DIFF
--- a/packages/codemirror-graphql/src/variables/lint.js
+++ b/packages/codemirror-graphql/src/variables/lint.js
@@ -18,6 +18,29 @@ import {
 
 import jsonParse from '../utils/jsonParse';
 
+CodeMirror.registerHelper(
+  'lint',
+  'json',
+  (text, options, editor) => {
+    // If there's no text, do nothing.
+    if (!text) {
+      return [];
+    }
+
+    // Then, linter needs to determine if there are any parsing errors.
+    try {
+      jsonParse(text);
+    } catch (syntaxError) {
+      if (syntaxError.stack) {
+        throw syntaxError;
+      }
+      return [lintError(editor, syntaxError, syntaxError.message)];
+    }
+
+    return  [];
+  },
+);
+
 /**
  * Registers a "lint" helper for CodeMirror.
  *

--- a/packages/codemirror-graphql/src/variables/mode.js
+++ b/packages/codemirror-graphql/src/variables/mode.js
@@ -11,11 +11,7 @@ import CodeMirror from 'codemirror';
 
 import { list, t, onlineParser, opt, p } from 'graphql-language-service-parser';
 
-/**
- * This mode defines JSON, but provides a data-laden parser state to enable
- * better code intelligence.
- */
-CodeMirror.defineMode('graphql-variables', config => {
+const modeCallback = (config) => {
   const parser = onlineParser({
     eatWhitespace: stream => stream.eatSpace(),
     lexRules: LexRules,
@@ -35,7 +31,14 @@ CodeMirror.defineMode('graphql-variables', config => {
       explode: '[]{}',
     },
   };
-});
+};
+
+/**
+ * This mode defines JSON, but provides a data-laden parser state to enable
+ * better code intelligence.
+ */
+CodeMirror.defineMode('graphql-variables', modeCallback);
+CodeMirror.defineMode('json', modeCallback);
 
 function indent(state, textAfter) {
   const levels = state.levels;

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -40,7 +40,7 @@ import getSelectedOperationName from '../utility/getSelectedOperationName';
 import debounce from '../utility/debounce';
 import find from '../utility/find';
 import { GetDefaultFieldNamesFn, fillLeafs } from '../utility/fillLeafs';
-import { getLeft, getTop } from '../utility/elementPosition';
+import { getLeft } from '../utility/elementPosition';
 import mergeAST from '../utility/mergeAst';
 import {
   introspectionQuery,
@@ -597,7 +597,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
                   onRunQuery={this.handleEditorRunQuery}
                   editorTheme={this.props.editorTheme}
                   readOnly={this.props.readOnly}
-                  mode={{ name: 'javascript', json: true }}
+                  mode='json'
                 />
               </section>
             </div>

--- a/packages/graphiql/src/components/VariableEditor.tsx
+++ b/packages/graphiql/src/components/VariableEditor.tsx
@@ -73,6 +73,7 @@ export class VariableEditor extends React.Component<VariableEditorProps> {
     require('codemirror/addon/fold/brace-fold');
     require('codemirror/addon/fold/foldgutter');
     require('codemirror/addon/lint/lint');
+    require('codemirror/addon/lint/json-lint');
     require('codemirror/addon/search/searchcursor');
     require('codemirror/addon/search/jump-to-line');
     require('codemirror/addon/dialog/dialog');


### PR DESCRIPTION
Adds improved linter support for JSON fields (e.g. the header editor).

This is basically the same as the variables field, but without the variable validation or hints/autocomplete.